### PR TITLE
Adiciona workflow de commit

### DIFF
--- a/.github/workflows/commit-workflow.yml
+++ b/.github/workflows/commit-workflow.yml
@@ -1,0 +1,30 @@
+name: Commit Workflow
+
+on:
+  push:
+    branches:
+      - main 
+      - 'feature/*'
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    
+    steps:
+      
+      - name: Checkout do código
+        uses: actions/checkout@v3
+
+      - name: instalar node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '20.16.0'  
+
+      
+      - name: instalar dependências
+        run: npm install 
+
+
+      
+      - name: Executar Testes
+        run: npm test  


### PR DESCRIPTION
Adiciona o seguinte workflow para eventos de commit: clona o repositório (devido ao fato de eu estar seguindo o GitHubFlow, não faz-se necessário mudar para outra branch), instala o node.js e as dependências do projeto e executa os testes.